### PR TITLE
Update DokWon token decimals + icon

### DIFF
--- a/cw20/tokens.js
+++ b/cw20/tokens.js
@@ -1734,8 +1734,8 @@ module.exports = {
       symbol: "DKW",
       name: "DokwonHub",
       token: "terra1x62dfgzrsksyemwuljhw9x0qcxefd3tpp4ued8",
-      icon: "https://pbs.twimg.com/profile_images/1663910755010314243/36qI92YG_400x400.jpg",
-      decimals: 6,
+      icon: "https://raw.githubusercontent.com/reglisosa/public/main/data/dokwon.png",
+      decimals: 2,
     },
   },
   testnet: {


### PR DESCRIPTION
DKW token has 2 decimals instead of 6. Also, I changed the icon link to the official one, which renders better with no background, instead of the previous one, which renders with black background.